### PR TITLE
Remove local iterators from imputation algorithms

### DIFF
--- a/statistical_methods_library/imputation.py
+++ b/statistical_methods_library/imputation.py
@@ -252,17 +252,14 @@ def imputation(
         # Since we're going to join on to the main df at the end filtering for
         # nulls won't cause us to lose strata as they'll just be filled with
         # default ratios.
-        filtered_df = (
-            df.filter(~df.output.isNull())
-            .select(
-                "ref",
-                "period",
-                "strata",
-                "output",
-                "aux",
-                "previous_period",
-                "next_period",
-            )
+        filtered_df = df.filter(~df.output.isNull()).select(
+            "ref",
+            "period",
+            "strata",
+            "output",
+            "aux",
+            "previous_period",
+            "next_period",
         )
 
         # Put the values from the current and previous periods for a
@@ -362,17 +359,14 @@ def imputation(
 
         # Avoid having to care about the name of our link column by selecting
         # it as a fixed name here.
-        working_df = (
-            df.select(
-                col("ref"),
-                col("period"),
-                col(link_col).alias("link"),
-                col("output"),
-                col("marker"),
-                col(other_period_col).alias("other_period"),
-            )
-            .persist()
-        )
+        working_df = df.select(
+            col("ref"),
+            col("period"),
+            col(link_col).alias("link"),
+            col("output"),
+            col("marker"),
+            col(other_period_col).alias("other_period"),
+        ).persist()
         # Anything which isn't null is already imputed or a response and thus
         # can be imputed from.
         imputed_df = (
@@ -433,9 +427,8 @@ def imputation(
         return impute(df, "backward", MARKER_BACKWARD_IMPUTE, False)
 
     def construct_values(df):
-        construction_df = (
-            df.filter(df.output.isNull())
-            .select("ref", "period", "aux", "construction", "previous_period")
+        construction_df = df.filter(df.output.isNull()).select(
+            "ref", "period", "aux", "construction", "previous_period"
         )
         other_df = construction_df.select("ref", "period").alias("other")
         construction_df = construction_df.alias("construction")


### PR DESCRIPTION
- Backward ratios can be calculated over the entire strata using the strata as part of the join
- ratio_union_df should be strata_ratio_df in final join
- Add strata column to forward calculated df
- Fix withColumn call
- Initial version of join-based forward ratio calculation
- Add next period into forward df for backward calculation
- reformat imputation code
- Fix duplicate rows caused by an incorrect join in the new forward ratio calculation
- Only impute is now iterative so no point in checkpointing each stage, instead persist at that point and only explicitly local checkpoint impute
- Reformat imputation using black
- Swap back to local checkpointing each stage to stop an rdd explosion
- Reformatted imputation
- Stop eager checkpointing after each stage
- Impute implemented as while loop with joins (equivalent to an sql recursive with)
- Repartition data for ratio calculation, imputation anc construction
- antijoin against calculation df in impute
- Pull repartitioning out since it seems to cause slowness
- Reformat imputation with black
