### PR TITLE
Update version of poetry used

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.3.2
       - name: Install dependencies
         run: poetry install
       - name: build
@@ -50,7 +50,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.3.2
       - name: Install dependencies
         run: poetry install
       - name: test
@@ -90,7 +90,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.3.2
       - name: Install dependencies
         run: poetry install
       - name: run flake8
@@ -116,7 +116,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.3.2
       - name: Install dependencies
         run: poetry install
       - name: run isort
@@ -142,7 +142,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.3.2
       - name: Install dependencies
         run: poetry install
       - name: run black

--- a/.github/workflows/package-release-artifact.yml
+++ b/.github/workflows/package-release-artifact.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.3.2
       - name: Install dependencies
         run: poetry install --no-dev
       - name: build


### PR DESCRIPTION
## Synopsis

this PR updates the version of poetry used in the github actions.

## Description

The project used an old version of Poetry (1.1.6) for packaging. This PR
updates this to 1.3.2 for compatibility with more modern tooling including
Dependabot.
