### PR TITLE
Stop type checking grouping cols

### DIFF
--- a/docs/release-notes/11.0.1.md
+++ b/docs/release-notes/11.0.1.md
@@ -4,22 +4,24 @@ Release date: 2023-03-08
 
 ## Synopsis
 
-Remove type validation for columns which are only used for data grouping.
+Remove type validation for columns which are only used for data identification.
 
 ## Changes
 
-Previously, columns only used for data grouping in methods were only allowed
-to contain data of StringType. This doesn't really make sense since these
-columns are only used in group by clauses and thus the type doesn't matter.
-This release removes these restrictions.
+Previously, columns used for data identification (both individual
+contributors and data grouping) in methods were only allowed to contain
+strings. This doesn't really make sense since these identification columns
+are only used in contexts where the type doesn't matter. This release
+removes these restrictions.
 
 ## Notes
 
 The effected methods and associated columns (named by method parameter) are
 as follows:
 
-* Imputation - `grouping_col`
-* HT Ratio Estimation - `strata_col` and `calibration_group_col`
-* Winsorisation - `grouping_col`
+* Imputation - `reference_col` and `grouping_col`
+* HT Ratio Estimation - `unique_identifier_col`, `strata_col` and
+  `calibration_group_col`
+* Winsorisation - `reference_col` and `grouping_col`
 
 This release does not have any impact on method outputs.

--- a/docs/release-notes/11.0.1.md
+++ b/docs/release-notes/11.0.1.md
@@ -1,0 +1,25 @@
+# Statistical Methods Library 11.0.1
+
+Release date: 2023-03-08
+
+## Synopsis
+
+Remove type validation for columns which are only used for data grouping.
+
+## Changes
+
+Previously, columns only used for data grouping in methods were only allowed
+to contain data of StringType. This doesn't really make sense since these
+columns are only used in group by clauses and thus the type doesn't matter.
+This release removes these restrictions.
+
+## Notes
+
+The effected methods and associated columns (named by method parameter) are
+as follows:
+
+* Imputation - `grouping_col`
+* HT Ratio Estimation - `strata_col` and `calibration_group_col`
+* Winsorisation - `grouping_col`
+
+This release does not have any impact on method outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "statistical_methods_library"
-version = "11.0.0"
+version = "11.0.1"
 description = ""
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/statistical_methods_library/estimation/ht_ratio.py
+++ b/statistical_methods_library/estimation/ht_ratio.py
@@ -148,12 +148,10 @@ def estimate(
     type_mapping = {
         "unique_identifier": StringType,
         "period": StringType,
-        "strata": StringType,
         "sample_marker": BooleanType,
         "adjustment_marker": StringType,
         "h_value": BooleanType,
         "auxiliary": DecimalType,
-        "calibration_group": StringType,
     }
 
     aliased_df = validation.validate_dataframe(

--- a/statistical_methods_library/estimation/ht_ratio.py
+++ b/statistical_methods_library/estimation/ht_ratio.py
@@ -1,5 +1,5 @@
 """
-Estimates design weigths and calibration factors based on Expansion and Ratio estimation.
+Estimates design weights and calibration factors based on Expansion and Ratio estimation.
 For Copyright information, please see LICENCE.
 """
 

--- a/statistical_methods_library/estimation/ht_ratio.py
+++ b/statistical_methods_library/estimation/ht_ratio.py
@@ -146,7 +146,6 @@ def estimate(
     input_params.update({k: v for k, v in optional_params.items() if v is not None})
 
     type_mapping = {
-        "unique_identifier": StringType,
         "period": StringType,
         "sample_marker": BooleanType,
         "adjustment_marker": StringType,

--- a/statistical_methods_library/imputation/engine.py
+++ b/statistical_methods_library/imputation/engine.py
@@ -116,7 +116,6 @@ def impute(
     }
 
     type_mapping = {
-        "ref": StringType,
         "period": StringType,
         "target": DecimalType,
         "aux": DecimalType,

--- a/statistical_methods_library/imputation/engine.py
+++ b/statistical_methods_library/imputation/engine.py
@@ -118,7 +118,6 @@ def impute(
     type_mapping = {
         "ref": StringType,
         "period": StringType,
-        "strata": StringType,
         "target": DecimalType,
         "aux": DecimalType,
         "output": DecimalType,

--- a/statistical_methods_library/outliering/winsorisation.py
+++ b/statistical_methods_library/outliering/winsorisation.py
@@ -117,7 +117,6 @@ def outlier(
     type_mapping = {
         "reference": StringType,
         "period": StringType,
-        "grouping": StringType,
         "target": DecimalType,
         "design": DecimalType,
         "l_value": DecimalType,

--- a/statistical_methods_library/outliering/winsorisation.py
+++ b/statistical_methods_library/outliering/winsorisation.py
@@ -115,7 +115,6 @@ def outlier(
     input_params.update({k: v for k, v in optional_params.items() if v is not None})
 
     type_mapping = {
-        "reference": StringType,
         "period": StringType,
         "target": DecimalType,
         "design": DecimalType,

--- a/statistical_methods_library/utilities/validation.py
+++ b/statistical_methods_library/utilities/validation.py
@@ -42,8 +42,10 @@ def validate_dataframe(
     wrong_types = [
         (field.name, field.dataType)
         for field in aliased_df.schema.fields
-        if field.name in type_mapping
+        if (
+            field.name in type_mapping
             and not isinstance(field.dataType, type_mapping[field.name])
+        )
     ]
     if wrong_types:
         raise ValidationError(

--- a/statistical_methods_library/utilities/validation.py
+++ b/statistical_methods_library/utilities/validation.py
@@ -42,7 +42,8 @@ def validate_dataframe(
     wrong_types = [
         (field.name, field.dataType)
         for field in aliased_df.schema.fields
-        if not isinstance(field.dataType, type_mapping[field.name])
+        if field.name in type_mapping
+            and not isinstance(field.dataType, type_mapping[field.name])
     ]
     if wrong_types:
         raise ValidationError(

--- a/tests/estimation/test_ht_ratio.py
+++ b/tests/estimation/test_ht_ratio.py
@@ -52,7 +52,7 @@ dataframe_types = {
 }
 
 bad_dataframe_types = dataframe_types.copy()
-bad_dataframe_types[unique_identifier_col] = decimal_type
+bad_dataframe_types[period_col] = decimal_type
 
 params = {
     "unique_identifier_col": unique_identifier_col,

--- a/tests/outliering/test_winsorisation.py
+++ b/tests/outliering/test_winsorisation.py
@@ -50,7 +50,7 @@ dataframe_types = {
 }
 
 bad_dataframe_types = dataframe_types.copy()
-bad_dataframe_types[reference_col] = decimal_type
+bad_dataframe_types[period_col] = decimal_type
 
 params = (
     reference_col,


### PR DESCRIPTION
- Stopped checking types of grouping col in winsorisation
- Allow strata and calibration group columns to be of any type as they are just grouping
- Strata is just a grouping col so allow it to be of any type
- Allow for not all fields to be type mapped in validation
- Spelling correction
- Add release notes
- Bump version

## Synopsis

Stop type checking columns only used for grouping data.

## Description

The grouping and identifier columns in the various methods were being forced
to only contain strings. Since these columns are only used to identify data
this type validation doesn't make sense. Specifically, in daily usage, it
has become clear that other data types are used for identifying data and
this type validation just causes unnecessary type casts whilst adding no
additional benefits.
