### PR TITLE
WP: Created catalog-info.yaml file for SDP (backstage) integration

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: statistical-methods-library
+  description: The Statistical Methods Library (S.M.L.) is a set of approved statistical methods.
+  annotations:
+    jira/project-key: SPP
+    github.com/project-slug: ONSdigital/statistical-methods-library
+  tags:
+    - python
+    - spp
+    - sml
+  links:
+      icon: search
+spec:
+  type: library
+  lifecycle: production
+  owner: group:spp-results


### PR DESCRIPTION
## Synopsis

### SDP integration

Created a catalog-info.yaml for software developer portal integration. This will let the user to access the GitHub repository in the backstage instance.
