### PR TITLE
fix release package naming discrepancy 13.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: abatilo/actions-poetry

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -27,7 +27,7 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java-version }}
       - name: Run image ${{matrix.python-version}}
-        uses: abatilo/actions-poetry@v3.0.0
+        uses: abatilo/actions-poetry@v2.4.0
         with:
           poetry-version: 1.5.1
       - name: Test ${{matrix.python-version}}
@@ -61,7 +61,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v3.0.0
+        uses: abatilo/actions-poetry@v2.4.0
         with:
           poetry-version: 1.5.1
       - name: Run flake8
@@ -82,7 +82,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v3.0.0
+        uses: abatilo/actions-poetry@v2.4.0
         with:
           poetry-version: 1.5.1
       - name: Run Black

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -14,7 +14,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        poetry-version: ["1.2.2", "1.7.1"]
         java-version: ['8']
       fail-fast: false 
     steps:
@@ -30,7 +29,7 @@ jobs:
       - name: Run image ${{matrix.python-version}}
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: 1.5.1
       - name: Test ${{matrix.python-version}}
         run: |-
           set -e
@@ -64,7 +63,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: 1.5.1
       - name: Run flake8
         run: |-
           poetry install
@@ -85,7 +84,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: 1.5.1
       - name: Run Black
         run: |-
           poetry install

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Run image ${{matrix.python-version}}
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.5.1
+          poetry-version: 1.8.3
       - name: Test ${{matrix.python-version}}
         run: |-
           set -e
@@ -63,7 +63,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.5.1
+          poetry-version: 1.8.3
       - name: Run flake8
         run: |-
           poetry install
@@ -84,7 +84,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.5.1
+          poetry-version: 1.8.3
       - name: Run Black
         run: |-
           poetry install

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -14,6 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
+        poetry-version: ["1.2.2", "1.7.1"]
         java-version: ['8']
       fail-fast: false 
     steps:
@@ -29,7 +30,7 @@ jobs:
       - name: Run image ${{matrix.python-version}}
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.2.1
+          poetry-version: ${{ matrix.poetry-version }}
       - name: Test ${{matrix.python-version}}
         run: |-
           set -e
@@ -63,7 +64,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.2.1
+          poetry-version: ${{ matrix.poetry-version }}
       - name: Run flake8
         run: |-
           poetry install
@@ -84,7 +85,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.2.1
+          poetry-version: ${{ matrix.poetry-version }}
       - name: Run Black
         run: |-
           poetry install

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Run image ${{matrix.python-version}}
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.8.3
+          poetry-version: 1.2.1
       - name: Test ${{matrix.python-version}}
         run: |-
           set -e
@@ -63,7 +63,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.8.3
+          poetry-version: 1.2.1
       - name: Run flake8
         run: |-
           poetry install
@@ -84,7 +84,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.8.3
+          poetry-version: 1.2.1
       - name: Run Black
         run: |-
           poetry install

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.8.3
+          poetry-version: 1.5.1
       - name: build
         run: poetry build
       - name: Create GitHub release

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: 1.5.1
+          poetry-version: 1.8.3
       - name: build
         run: poetry build
       - name: Create GitHub release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "statistical_methods_library"
-version = "13.1.2"
+version = "13.3.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/release-notes/13.3.0.md
+++ b/release-notes/13.3.0.md
@@ -8,10 +8,10 @@ This release imputation method accepts and appropriately handles cases where a v
 
 ## Changes
 
-The imputation method now has an optional imputation parameter named "manual_construction_col." When this argument is given together with the relevant column in the "input_df" dataframe, the method performs the manual construction and forwards imputes from manual construction for the nonresponder.
+The imputation method now has an optional imputation parameter named "manual_construction_col." When this argument is given together with the relevant column in the "input_df" dataframe, the method performs the manual construction and forwards imputes from manual construction for non-responders.
 
 
 ## Notes
 
-When the manual construction is applied, the output will have the markers MC or FIMC.
+When manual construction or forward imputation from manual construction is applied, the output will have the markers MC or FIMC.
 This change has no impact on the link calculation.

--- a/release-notes/13.3.0.md
+++ b/release-notes/13.3.0.md
@@ -1,0 +1,17 @@
+# Statistical Methods Library 13.3.0
+
+Release date: 2025-07-16
+
+## Synopsis
+
+This release imputation method accepts and appropriately handles cases where a value has been overridden by manual intervention or manual construction.
+
+## Changes
+
+The imputation method now has an optional imputation parameter named "manual_construction_col." When this argument is given together with the relevant column in the "input_df" dataframe, the method performs the manual construction and forwards imputes from manual construction for the nonresponder.
+
+
+## Notes
+
+When the manual construction is applied, the output will have the markers MC or FIMC.
+This change has no impact on the link calculation.


### PR DESCRIPTION
## Synopsis
SPP-11735
The SML releases packages for versions 13.2.0 and 13.3.0 still have the prior version number, 13.1.2, in their names.The main reason for this is that the statistical-method-library project's pyproject.toml was pointing to an earlier version 13.1.2 when later release versions were created.

Python 3.7 is no longer supported by the most recent version of the github action **abatilo/actions-poetry**, which is causing flake8, black, and unittest on Python 3.7 to fail.

- Updated the pyproject.toml version to 13.3.0
- Updated the abatilo/actions-poetry version to 2.4.0 when python 3.7 been used. and Ignore the dependantbot update ont he same.
- Added release note for 13.3.0 

## Checklist

- [ ] Documentation created/updated
- [ ] Tests created/updated

## Description

Add a more detailed description of the pr if necessary (can reference release
notes if included).
